### PR TITLE
Allow usage of Ansible module group defaults

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,15 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: ">=2.9.10"
+action_groups:
+  netapp_um_info:
+    - na_um_aggregates_info
+    - na_um_clusters_info
+    - na_um_list_aggregates
+    - na_um_list_clusters
+    - na_um_list_nodes
+    - na_um_list_svms
+    - na_um_list_volumes.p
+    - na_um_list_volumes
+    - na_um_nodes_info
+    - na_um_svms_info
+    - na_um_volumes_info


### PR DESCRIPTION
##### SUMMARY
Allow usage of Ansible module group defaults

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html

##### ADDITIONAL INFORMATION
Allows usage of module defaults like:
```
- hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - netapp.um_info
  module_defaults:
    group/netapp.ontap.netapp_um_info:
       # common options goes here
```