### PR TITLE
Resolve Installation Error for "netapp.um_info" Collection by Updating Path Configuration

### DIFF
--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,3 +1,3 @@
 version: 1
 dependencies:
-  python: ../requirements.txt
+  python: requirements.txt


### PR DESCRIPTION
##### SUMMARY
Installation of "netapp.um_info" Ansible collection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- Ansible Collection: netapp.um_info

##### ADDITIONAL INFORMATION
- Fixed the installation failure of the "netapp.um_info" Ansible collection due to an incorrect path mentioned in the `meta/execution-environment.yml` file.
- Previously, attempting to build the execution environment and install the "netapp.um_info" collection resulted in the following error:
```
Running command:
  podman build -f context/Containerfile -t localhost/test_ee:latest context
...showing last 20 lines of output...
--> 8378c8824280
[3/4] STEP 11/12: RUN $PYCMD /output/scripts/introspect.py introspect --sanitize --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt
Expected requirements file not present at: /usr/share/ansible/collections/ansible_collections/netapp/requirements.txt
Traceback (most recent call last):
  File "/output/scripts/introspect.py", line 401, in <module>
    main()
  File "/output/scripts/introspect.py", line 394, in main
    run_introspect(args, logger)
  File "/output/scripts/introspect.py", line 232, in run_introspect
    data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
  File "/output/scripts/introspect.py", line 99, in process
    col_pip_lines, col_sys_lines = process_collection(path)
  File "/output/scripts/introspect.py", line 68, in process_collection
    pip_lines = pip_file_data(os.path.join(path, py_file))
  File "/output/scripts/introspect.py", line 28, in pip_file_data
    pip_content = read_req_file(path)
  File "/output/scripts/introspect.py", line 23, in read_req_file
    with open(path, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/ansible/collections/ansible_collections/netapp/um_info/../requirements.txt'
Error: building at STEP "RUN $PYCMD /output/scripts/introspect.py introspect --sanitize --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt": while running runtime: exit status 1

An error occurred (rc=1), see output line(s) above for details.
```
- The issue was resolved by correcting the path in `meta/execution-environment.yml`, enabling successful installation.